### PR TITLE
Minor refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,22 +89,15 @@ fn test_architecture_baseline() {
 
         .finalize();
 
-    let result = Arkitect::ensure_that(project).complies_with(rules);
-
     let baseline_violations = 30;
+    let result = Arkitect::ensure_that(project).with_baseline(baseline_violations).complies_with(rules);
 
-    match result {
-        Ok(_) => panic!("Expected at least {} violations, but found none!", baseline_violations),
-        Err(violations) => {
-            let current_violations = violations.len();
-            assert!(
-                current_violations <= baseline_violations,
-                "Violations increased! Expected at most {}, found {}.",
-                baseline_violations,
-                current_violations
-            );
-        }
-    }
+    assert!(
+        result.is_ok(),
+        "Violations increased! Expected at most {}, found {}.",
+        baseline_violations,
+        current_violations
+    );
 }
 ```
 This test ensures that the number of violations does not exceed the established baseline, promoting continuous improvement in your codebase's architecture.

--- a/tests/test_architecture.rs
+++ b/tests/test_architecture.rs
@@ -1,44 +1,42 @@
-#[cfg(test)]
-mod tests {
-    use rust_arkitect::dsl::{ArchitecturalRules, Arkitect, Project};
-    use std::result;
+#![cfg(test)]
 
-    #[test]
-    fn test_compliance() {
-        Arkitect::init_logger();
+use rust_arkitect::dsl::{ArchitecturalRules, Arkitect, Project};
 
-        let project = Project::from_relative_path(file!(), "./../src");
+#[test]
+fn test_compliance() {
+    Arkitect::init_logger();
 
-        #[rustfmt::skip]
-        let rules = ArchitecturalRules::define()
-            .component("DSL")
-                .located_at("crate::dsl")
-                .allow_external_dependencies(&["std::collections", "std::marker::PhantomData", "std::path"])
-                .may_depend_on(&["Engine", "Rules"])
+    let project = Project::from_relative_path(file!(), "./../src");
 
-            .component("Engine")
-                .located_at("crate::engine")
-                .allow_external_dependencies(&["ansi_term", "log", "std::fs"])
-                .may_depend_on(&["Rules"])
+    #[rustfmt::skip]
+    let rules = ArchitecturalRules::define()
+        .component("DSL")
+            .located_at("crate::dsl")
+            .allow_external_dependencies(&["std::collections", "std::marker::PhantomData", "std::path"])
+            .may_depend_on(&["Engine", "Rules"])
 
-            .component("Rules")
-                .located_at("crate::rules")
-                .allow_external_dependencies(&["ansi_term", "log", "std::fmt"])
-                .may_depend_on(&["DependencyParsing"])
+        .component("Engine")
+            .located_at("crate::engine")
+            .allow_external_dependencies(&["ansi_term", "log", "std::fs"])
+            .may_depend_on(&["Rules"])
 
-            .component("DependencyParsing")
-                .located_at("crate::dependency_parsing")
-                .allow_external_dependencies(&["syn", "quote", "std::path", "std::ops", "std::fs"])
-                .must_not_depend_on_anything()
+        .component("Rules")
+            .located_at("crate::rules")
+            .allow_external_dependencies(&["ansi_term", "log", "std::fmt"])
+            .may_depend_on(&["DependencyParsing"])
 
-            .finalize();
+        .component("DependencyParsing")
+            .located_at("crate::dependency_parsing")
+            .allow_external_dependencies(&["syn", "quote", "std::path", "std::ops", "std::fs"])
+            .must_not_depend_on_anything()
 
-        let result = Arkitect::ensure_that(project).complies_with(rules);
+        .finalize();
 
-        assert!(
-            result.is_ok(),
-            "Detected {} violations",
-            result.err().unwrap().len()
-        );
-    }
+    let result = Arkitect::ensure_that(project).complies_with(rules);
+
+    assert!(
+        result.is_ok(),
+        "Detected {} violations",
+        result.err().unwrap().len()
+    );
 }


### PR DESCRIPTION
This PR make the following changes:

- Removes a number of uses of unnecessary `clone` and `to_string`.
- Adds the baseline check as a feature (although maybe this should be implemented as a list of expected violations (thoughts?)
- Implements a number of other minor refactorings (adding a `IsChild` trait, make engine a struct)
- Fix clippy warnings